### PR TITLE
Update ResultSet.cls

### DIFF
--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -157,6 +157,7 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 	
 	try {
 		set cell.path = ##class(%DeepSee.Query.Engine).%GetSpecForAxisNode(CubeName, QueryKey, AxisNumber, Node) // MDX cell path
+		set cell.path = $TRANSLATE(cell.path, "()", "") // removing redundant parentheses
 	} catch ex {
 		set cell.path = "path too long"		
 	}


### PR DESCRIPTION
Adding $TRANSLATE function to removing redundant parentheses on "path" parameter.

Today state:
![2022-12-27_15-44-26](https://user-images.githubusercontent.com/47441164/209687680-6bc96243-39b0-4f3e-954e-0864c377e7ba.png)


Desired state:
![2022-12-27_20-25-12](https://user-images.githubusercontent.com/47441164/209687710-507b0afe-6315-4220-81ee-acde5dcf73d4.png)


State after fix:
![2022-12-27_20-25-12](https://user-images.githubusercontent.com/47441164/209687719-d8ae63ca-36ea-4a1d-a101-0a78e58a9361.png)
