### PR TITLE
FIX: Get right cube name for action execution

### DIFF
--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -346,7 +346,7 @@ ClassMethod ExecuteAction(Cube As %String, Action As %String, Context As %ZEN.pr
 {
 	set st = $$$OK
 	set Cube = $$$UPPER(Cube)
-	if $FIND(Cube, ".KPI") set Cube = $TRANSLATE(Cube, ".KPI", "") // cut off resolution ".kpi" from Cube name if there any 
+	if $FIND(Cube, ".KPI") set Cube = $TRANSLATE(Cube, ".KPI", "") // cut off extension ".kpi" from Cube name if there any 
 	set ActionClass = $G($$$DeepSeeMetaGLVN("cubes",Cube,"actionClass"), $G($$$DeepSeeMetaGLVN("kpis",Cube)))
 	if (ActionClass'="") {
 		set st = $classmethod(ActionClass,"%OnDashboardAction",Action,Context)

--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -346,7 +346,7 @@ ClassMethod ExecuteAction(Cube As %String, Action As %String, Context As %ZEN.pr
 {
 	set st = $$$OK
 	set Cube = $$$UPPER(Cube)
-	if $FIND(Cube, ".KPI") set Cube = $TRANSLATE(Cube, ".KPI", "") // cut off extension ".kpi" from Cube name if there any 
+	set:$FIND(Cube, ".KPI") Cube = $TRANSLATE(Cube, ".KPI", "") // cut off extension ".kpi" from Cube name if there any 
 	set ActionClass = $G($$$DeepSeeMetaGLVN("cubes",Cube,"actionClass"), $G($$$DeepSeeMetaGLVN("kpis",Cube)))
 	if (ActionClass'="") {
 		set st = $classmethod(ActionClass,"%OnDashboardAction",Action,Context)

--- a/MDX2JSON/Utils.cls
+++ b/MDX2JSON/Utils.cls
@@ -346,6 +346,7 @@ ClassMethod ExecuteAction(Cube As %String, Action As %String, Context As %ZEN.pr
 {
 	set st = $$$OK
 	set Cube = $$$UPPER(Cube)
+	if $FIND(Cube, ".KPI") set Cube = $TRANSLATE(Cube, ".KPI", "") // cut off resolution ".kpi" from Cube name if there any 
 	set ActionClass = $G($$$DeepSeeMetaGLVN("cubes",Cube,"actionClass"), $G($$$DeepSeeMetaGLVN("kpis",Cube)))
 	if (ActionClass'="") {
 		set st = $classmethod(ActionClass,"%OnDashboardAction",Action,Context)


### PR DESCRIPTION
Corresponding issue https://github.com/intersystems-community/DeepSeeWeb/issues/336
The fix checks if Cube string has ".KPI" and cut if off if it has  