### PR TITLE
FIX: add missing property for text meter

### DIFF
--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -189,7 +189,7 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 
 	do ##class(%DeepSee.Utils).%GetDimensionCaption(CubeName,tDimNo, tHierNo,tLevelNo, .tAxisCaption)
 	set cell.dimension = tAxisCaption // cube dimension
-	if (cell.dimension) = "" {set cell.dimension = tCaption} // hack for assigne dimension property for calcMembers specifically
+	if (cell.dimension = "") {set cell.dimension = tCaption} // hack for assigne dimension property for calcMembers specifically
 	
 
 	set:$$$Debug cell.visible = '..IsCellNull(cell,AxisNumber,Node)

--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -189,7 +189,7 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 
 	do ##class(%DeepSee.Utils).%GetDimensionCaption(CubeName,tDimNo, tHierNo,tLevelNo, .tAxisCaption)
 	set cell.dimension = tAxisCaption // cube dimension
-	if (cell.dimension) = "" set cell.dimension = tCaption // hack for assigne dimension property for calcMembers specifically
+	if (cell.dimension) = "" {set cell.dimension = tCaption} // hack for assigne dimension property for calcMembers specifically
 	
 
 	set:$$$Debug cell.visible = '..IsCellNull(cell,AxisNumber,Node)

--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -185,10 +185,12 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 	set tDimNo = $LG(tNode,9)
 	set tHierNo = $LG(tNode,10)
 	set tLevelNo = $LG(tNode,11)
+	set tCaption = $LG(tNode, 5)
 
 	do ##class(%DeepSee.Utils).%GetDimensionCaption(CubeName,tDimNo, tHierNo,tLevelNo, .tAxisCaption)
 	set cell.dimension = tAxisCaption // cube dimension
-
+	if (cell.dimension) = "" set cell.dimension = tCaption // hack for assigne dimension property for calcMembers specifically
+	
 
 	set:$$$Debug cell.visible = '..IsCellNull(cell,AxisNumber,Node)
 	set:$$$Debug cell.node = Node


### PR DESCRIPTION
The hack simply takes the measure name and assigns it to the dimension property. Unique Doctor Count is calcMember and any other measure is mbr#. The method in ResultSet looked for mbr# and therefore did not find it

Related issue
https://github.com/intersystems-community/DeepSeeWeb/issues/324