### PR TITLE
FIX: add fix for textMeters

### DIFF
--- a/MDX2JSON/ResultSet.cls
+++ b/MDX2JSON/ResultSet.cls
@@ -188,7 +188,7 @@ Method ProcessOneAxisCell(CubeIndex, AxisKey, CubeName, QueryKey, AxisNumber, No
 	set tCaption = $LG(tNode, 5)
 
 	do ##class(%DeepSee.Utils).%GetDimensionCaption(CubeName,tDimNo, tHierNo,tLevelNo, .tAxisCaption)
-	set cell.dimension = tAxisCaption // cube dimension
+	set cell.dimension = tCaption // cube dimension taken from the name of the axes.
 	if (cell.dimension = "") {set cell.dimension = tCaption} // hack for assigne dimension property for calcMembers specifically
 	
 


### PR DESCRIPTION
The dimension of the cube is taken from the names of the axes. The solution needs to be tested on a pie-chart, further work on the solution is possible 
Related issue
https://github.com/intersystems-community/DeepSeeWeb/issues/348